### PR TITLE
Release v1.3.4

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -15,6 +15,9 @@ docs/
 CLAUDE.md
 CONTRIBUTING.md
 
+# Claude Code config
+.claude/
+
 # IDE
 .idea/
 .vscode/

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -73,6 +73,51 @@ add_filter( 'tgp_llms_txt_pages', function( $pages ) {
 
 ---
 
+### `tgp_llms_txt_posts_limit`
+
+Filter the maximum number of posts to include in the llms.txt output.
+
+**Since:** 1.3.4
+
+**Parameters:**
+- `$limit` (int) Maximum number of posts. Default 50. Use -1 for unlimited.
+
+**Example:**
+
+```php
+// Limit to 20 most recent posts
+add_filter( 'tgp_llms_txt_posts_limit', function( $limit ) {
+    return 20;
+} );
+
+// Include all posts (not recommended for large sites)
+add_filter( 'tgp_llms_txt_posts_limit', function( $limit ) {
+    return -1;
+} );
+```
+
+---
+
+### `tgp_llms_txt_exclude_categories`
+
+Filter the categories to exclude from the llms.txt output.
+
+**Since:** 1.3.4
+
+**Parameters:**
+- `$exclude_categories` (array) Array of category slugs to exclude. Default empty.
+
+**Example:**
+
+```php
+// Exclude internal and draft categories
+add_filter( 'tgp_llms_txt_exclude_categories', function( $categories ) {
+    return [ 'internal', 'drafts', 'uncategorized' ];
+} );
+```
+
+---
+
 ### `tgp_llms_txt_rate_limit`
 
 Filter the rate limit for LLMs.txt endpoints (requests per minute).

--- a/includes/EndpointHandler.php
+++ b/includes/EndpointHandler.php
@@ -54,8 +54,8 @@ class EndpointHandler {
 		$path = wp_parse_url( $request_uri, PHP_URL_PATH );
 		$path = rtrim( $path, '/' );
 
-		// Check for llms.txt
-		if ( preg_match( '/\/llms\.txt$/i', $path ) ) {
+		// Check for llms.txt - only match root /llms.txt, not /blog/slug/llms.txt
+		if ( '/llms.txt' === strtolower( $path ) ) {
 			$this->serve_llms_txt();
 			exit;
 		}
@@ -97,9 +97,9 @@ class EndpointHandler {
 			'top'
 		);
 
-		// Match /llms.txt
+		// Match /llms.txt (root only)
 		add_rewrite_rule(
-			'llms\.txt$',
+			'^llms\.txt$',
 			'index.php?tgp_llms_txt=1',
 			'top'
 		);

--- a/tests/e2e/endpoints.spec.js
+++ b/tests/e2e/endpoints.spec.js
@@ -24,7 +24,7 @@ test.describe( 'LLMs.txt endpoint', () => {
 		// Should contain expected content structure.
 		const content = await response.text();
 		expect( content ).toContain( '# ' ); // Site name header.
-		expect( content ).toContain( 'llms.txt' );
+		expect( content ).toContain( 'Last Updated:' ); // Timestamp.
 		expect( content ).toContain( 'https://llmstxt.org/' ); // Standard reference.
 	} );
 

--- a/tests/php/includes/GeneratorCacheTest.php
+++ b/tests/php/includes/GeneratorCacheTest.php
@@ -105,7 +105,9 @@ class GeneratorCacheTest extends TestCase {
 		$generator = new Generator();
 		$result    = $generator->generate();
 
-		$this->assertStringContainsString( '# Test Site - llms.txt', $result );
+		$this->assertStringContainsString( '# Test Site', $result );
+		$this->assertStringContainsString( '> Test Site', $result );
+		$this->assertStringContainsString( 'Last Updated:', $result );
 	}
 
 	/**

--- a/tgp-llms-txt.php
+++ b/tgp-llms-txt.php
@@ -3,7 +3,7 @@
  * Plugin Name: TGP LLMs.txt
  * Plugin URI: https://thegrowthproject.com
  * Description: Provides markdown endpoints for AI/LLM consumption. Adds .md URLs, /llms.txt index, and "Copy for LLM" buttons.
- * Version: 1.3.3
+ * Version: 1.3.4
  * Requires at least: 6.5
  * Author: The Growth Project
  * Author URI: https://thegrowthproject.com
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'TGP_LLMS_VERSION', '1.3.3' );
+define( 'TGP_LLMS_VERSION', '1.3.4' );
 define( 'TGP_LLMS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'TGP_LLMS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
## Summary

Patch release with bug fix and llms.txt generator improvements.

### Bug Fix
- **Root-only /llms.txt**: Fixed issue #30 where `/blog/post-slug/llms.txt` incorrectly returned home page content instead of 404. The `/llms.txt` endpoint now only matches at the site root.

### Generator Improvements (llmstxt.org compliance)
- **Posts limit filter**: Added `tgp_llms_txt_posts_limit` filter (default 50, use -1 for unlimited)
- **Category exclusion**: Added `tgp_llms_txt_exclude_categories` filter to exclude categories by slug
- **Post dates**: Each post listing now includes its publish date
- **Last Updated timestamp**: Header now includes `Last Updated: YYYY-MM-DD`
- **Cleaner format**: Simplified header to match llmstxt.org spec

### Files Changed
- `includes/EndpointHandler.php` - Root-only matching for /llms.txt
- `includes/Generator.php` - New filters, dates, improved format
- `docs/HOOKS.md` - Documentation for new filters
- `tests/e2e/endpoints.spec.js` - Updated for new format
- `tests/php/includes/GeneratorCacheTest.php` - Updated for new format

## Test Plan
- [x] All PHPUnit tests pass (140 tests)
- [x] All E2E tests pass
- [x] PHPCS linting passes
- [x] PHPStan static analysis passes
- [x] Security audit passes

## Related Issues
Closes #30